### PR TITLE
refactor(config): Upgrade to winnow 0.5 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
  "self_update",
  "strum",
  "thiserror",
- "winnow",
+ "winnow 0.5.0",
 ]
 
 [[package]]
@@ -2151,7 +2151,7 @@ checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.9",
 ]
 
 [[package]]
@@ -2551,6 +2551,15 @@ name = "winnow"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ itertools = "0.11.0"
 reqwest = { version = "0.11", default-features = false, optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.43"
-winnow = "0.4.9"
+winnow = "0.5.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ fn make_transformer(
 pub(crate) fn parse(src: &str) -> Result<Config, anyhow::Error> {
     let result = parser::parse_config
         .parse(src)
-        .map_err(|e| e.into_owned())?;
+        .map_err(|e| anyhow::format_err!("{e}"))?;
 
     let mut source = None;
     let mut builder = MutationsBuilder::new();

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -3,15 +3,15 @@ use std::collections::HashMap;
 
 use winnow::ascii::escaped_transform;
 use winnow::ascii::space1;
-use winnow::branch::alt;
-use winnow::bytes::one_of;
-use winnow::bytes::take_till0;
-use winnow::bytes::take_till1;
+use winnow::combinator::alt;
+use winnow::combinator::delimited;
 use winnow::combinator::opt;
+use winnow::combinator::preceded;
+use winnow::combinator::separated0;
 use winnow::error::VerboseError;
-use winnow::multi::separated0;
-use winnow::sequence::delimited;
-use winnow::sequence::preceded;
+use winnow::token::one_of;
+use winnow::token::take_till0;
+use winnow::token::take_till1;
 use winnow::IResult;
 use winnow::Parser;
 


### PR DESCRIPTION
Note: this does include a bug fix that a compile error caught.
`one_of(("\n", "\r", "\r\n"))` was actually treating `"\r\n"` as a set
of characters to match and was redundant.  This is now `alt(("\r\n", "\n", "\r"))`