### PR TITLE
feat: Switch everything to use ring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_PROFILE_DEV_DEBUG: 1
-      CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: "packed"
+      CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: ${{ matrix.debug_info }}
       RUSTFLAGS: -D warnings -Clink-arg=-Wl,--compress-debug-sections=zlib
     strategy:
       fail-fast: false
@@ -41,9 +41,23 @@ jobs:
           #- x86_64-pc-windows-gnu
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
+          # Some lower priority targets too (not currently built as releases)
+          - i586-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
         rust:
           - stable
           - nightly
+        debug_info:
+          - packed
+        include:
+          # RISCV doesn't work with split debug info (see rust-lang/rust#110224)
+          - target: riscv64gc-unknown-linux-gnu
+            rust: stable
+            debug_info: off
+          - target: riscv64gc-unknown-linux-gnu
+            rust: nightly
+            debug_info: off
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -63,7 +77,10 @@ jobs:
         run: |
           mkdir chezmoi_modify_manager
           cp target/${{ matrix.target }}/debug/chezmoi_modify_manager chezmoi_modify_manager/
-          cp target/${{ matrix.target }}/debug/chezmoi_modify_manager.dwp chezmoi_modify_manager/
+          if [[ -f target/${{ matrix.target }}/debug/chezmoi_modify_manager.dwp ]]; then
+            # No split debug info for RISCV
+            cp target/${{ matrix.target }}/debug/chezmoi_modify_manager.dwp chezmoi_modify_manager/
+          fi
           tar cf chezmoi_modify_manager.tar chezmoi_modify_manager
           zstd -T0 -6 chezmoi_modify_manager.tar
       - uses: actions/upload-artifact@v4
@@ -85,9 +102,8 @@ jobs:
       matrix:
         features:
           - --no-default-features
-          - --no-default-features --features=updater-tls-native
-          - --no-default-features --features=updater-tls-native-vendored
-          - --no-default-features --features=updater-tls-rusttls,keyring
+          - --no-default-features --features=updater-tls-rusttls
+          - --no-default-features --features=keyring
         rust:
           - 1.71.0
           - stable
@@ -103,36 +119,6 @@ jobs:
         run: cargo test --locked ${{ matrix.features }} --verbose --no-run
       - name: Test
         run: cargo test --locked ${{ matrix.features }} --verbose
-
-  exotic-linux:
-    # Test exotic Linux configs that only work with vendored OpenSSL
-    name: "Test: ${{ matrix.target }}, Rust ${{ matrix.rust }} (vendored OpenSSL)"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - i586-unknown-linux-gnu
-          - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          # OpenSSL broken on RISCV
-          #- riscv64gc-unknown-linux-gnu
-        rust:
-          - stable
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup install --profile minimal  ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - name: Install cross
-        uses: taiki-e/install-action@cross
-      - name: Cache builds
-        uses: Swatinem/rust-cache@v2.7.3
-        with:
-          key: ${{ matrix.target }}
-      - name: Cross compile
-        run: cross test --locked --no-default-features --features=updater-tls-native-vendored --target ${{ matrix.target }} --verbose --no-run
-      - name: Cross test
-        run: cross test --locked --no-default-features --features=updater-tls-native-vendored --target ${{ matrix.target }} --verbose
 
   exotic-os:
     # Test native builds on non-Linux platforms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,6 @@ dependencies = [
  "os_info",
  "pathdiff",
  "pretty_assertions",
- "reqwest",
  "rustc_version_runtime",
  "self_update",
  "strum",
@@ -850,21 +849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,19 +1122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,24 +1370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,60 +1522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "300.2.1+3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,12 +1635,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "platforms"
@@ -1947,12 +1840,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1963,7 +1854,6 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -2082,15 +1972,6 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
-
-[[package]]
-name = "schannel"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "sct"
@@ -2506,16 +2387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,12 +2542,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,7 @@ version = "3.0.0"
 default = ["updater-tls-rusttls", "keyring"]
 # Support for keyring transform
 keyring = ["ini-merge/keyring"]
-# Built in updater, distro packages probably wants to disable this.
-# This is the version based on native TLS: platform OpenSSL or platform specific
-updater-tls-native = ["self_update", "reqwest", "reqwest/default-tls"]
-# Built in updater, distro packages probably wants to disable this.
-# This is the version based on vendored OpenSSL
-updater-tls-native-vendored = [
-    "self_update",
-    "reqwest",
-    "reqwest/native-tls-vendored",
-]
-# Built in updater, distro packages probably wants to disable this.
-# This is the version based on RustTLS: TLS entirely in rust.
+# Built in updater, distro packages probably wants to disable this. Uses rustls for encryption.
 updater-tls-rusttls = ["self_update", "self_update/rustls"]
 
 [target.'cfg(windows)'.dependencies]
@@ -63,7 +52,6 @@ ini-merge = { version = "0.4.0", default-features = false }
 itertools = { version = "0.12.0", default-features = false }
 log = { version = "0.4.20", default-features = false }
 os_info = { version = "3.7.0", default-features = false }
-reqwest = { version = "0.11", default-features = false, optional = true }
 rustc_version_runtime = { version = "0.3.0", default-features = false }
 strum = { version = "0.25.0", features = [
     "derive",


### PR DESCRIPTION
Supposedly this now works (ring supports more architectures). Investigate if we can drop OpenSSL as an option entirely and also enable releases for additional linux architectures.