### PR TITLE
feat: Add support for upcoming CHEZMOI_SOURCE_FILE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "os_info",
  "pathdiff",
  "pretty_assertions",
+ "regex",
  "rustc_version_runtime",
  "self_update",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ ini-merge = { version = "0.4.0", default-features = false }
 itertools = { version = "0.12.1", default-features = false }
 log = { version = "0.4.20", default-features = false }
 os_info = { version = "3.7.0", default-features = false }
+regex = "1.10.3"
 rustc_version_runtime = { version = "0.3.0", default-features = false }
 strum = { version = "0.26.1", features = [
     "derive",

--- a/README.md
+++ b/README.md
@@ -207,10 +207,13 @@ not considered a breaking change and as such may change even in a patch version.
 ## Troubleshooting
 
 The first step should be to run `chezmoi_modify_manager --doctor` and correct
-any issues reported. This will help identify the two common issues:
+any issues reported. This will help identify two common issues:
 
 * chezmoi_modify_manager needs to be in `PATH`
 * `**/*.src.ini` needs to be ignored in the root `.chezmoiignore` file
+* Old chezmoi and/or using `CHEZMOI_MODIFY_MANAGER_ASSUME_CHEZMOI_VERSION`, see
+  [this documentation](doc/source_specification.md) for more details on when or
+  when not to use this.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ INI files when managing the configuration files with chezmoi.
 For each settings file you want to manage with `chezmoi_modify_manager` there
 will be two files in your chezmoi source directory:
 
-* `modify_<config file>.tmpl`, eg. `modify_private_kdeglobals.tmpl` \
+* `modify_<config file>` or `modify_<config file>.tmpl`, eg. `modify_private_kdeglobals.tmpl` \
   This is the modify script/configuration file that calls `chezmoi_modify_manager`.
   It contains the directives describing what to ignore.
 * `<config file>.src.ini`, eg. `private_kdeglobals.src.ini`\
@@ -53,6 +53,13 @@ will tell it to ignore the key `Show Inline Previews` in the section
 
 **Note!** If a key appears before the first section, use `<NO_SECTION>` as the
 section.
+
+**Note!** The modify script can itself be a chezmoi template (if it ends with
+`.tmpl`), which can be useful if you want to do host specific configuration using
+the `set` directive for [example](doc/examples.md#examples---setremove).
+This however will slow things down every so slightly as chezmoi has to run its
+templating engine on the file. Typically this will be an overhead of about half
+a millisecond per templated modify script (measured on an AMD Ryzen 5 5600X).
 
 ### Supported features
 
@@ -199,8 +206,8 @@ not considered a breaking change and as such may change even in a patch version.
 
 ## Troubleshooting
 
-The first step should be to run `chezmoi_modify_manager --doctor` and correct any issues reported.
-This will help identify the two common issues:
+The first step should be to run `chezmoi_modify_manager --doctor` and correct
+any issues reported. This will help identify the two common issues:
 
 * chezmoi_modify_manager needs to be in `PATH`
 * `**/*.src.ini` needs to be ignored in the root `.chezmoiignore` file

--- a/doc/source_specification.md
+++ b/doc/source_specification.md
@@ -1,0 +1,75 @@
+# `source`: How chezmoi_modify_manager finds the data file
+
+## Background
+
+chezmoi_modify_manager needs three inputs to work:
+
+* The modify script with directives (ignores, transforms, etc)
+* The state of the config file in your home directory
+* The source state of the config file.
+
+The first two are provided by chezmoi, no issues. But as far as chezmoi is
+concerned, the modify script itself is the source state. As such we need
+an alternative mechanism.
+
+## Problem
+
+The obvious solution would be a path relative to the modify script. However,
+chezmoi always copies the modify script to a temporary directory before executing
+it, even if the modify script isn't templated. So this doesn't work. (It is however
+used internally in the test suite of chezmoi_modify_manager using
+`source auto-path`, which might be relevant if you are working on the 
+chezmoi_modify_manager codebase itself.)
+
+Prior to chezmoi 2.46.1, we had to rely on making the modify script a template,
+as chezmoi didn't expose enough information to us (see
+[this chezmoi issue](https://github.com/twpayne/chezmoi/issues/2934) for more
+historical details). Basically we can make chezmoi find the source file for us
+using the following line:
+
+```
+source "{{ .chezmoi.sourceDir }}/{{ .chezmoi.sourceFile | trimSuffix ".tmpl" | replace "modify_" "" }}.src.ini"
+```
+
+Since chezmoi 2.46.1, chezmoi now provides us with two environment variables:
+
+* `CHEZMOI_SOURCE_DIR`: Path to the source directory root
+* `CHEZMOI_SOURCE_FILE`: Path to our modify script (relative the source directory root)
+
+With these two together we no longer need templating, and the following works:
+
+```
+source auto
+```
+
+## What the code does
+
+Since chezmoi_modify_manager 3.1, it will auto detect the version of chezmoi
+(based on executing `chezmoi --version`). This is used for:
+
+* The template that `--add` creates to either use the templated source string or
+  the simpler `source auto`.
+* Interpreting the meaning of `--style=auto` (default value for style) to either
+  create a templated modify script or a non-templated modify script.
+  
+The main benefit of the simpler `source auto` is that if your modify script
+*doesn't need* to be a template for any other reason, it will speed up execution,
+as chezmoi no longer needs to run its template engine.
+
+### Overriding auto detection
+
+Auto detection has one downside though: What if you use multiple versions of
+chezmoi (such as an old version from Debian stable on some server but an up-to-date
+version on your personal computer). In that case you don't want to use the newer
+syntax for compatibility reasons.
+
+The workaround is to export an environment
+variable `CHEZMOI_MODIFY_MANAGER_ASSUME_CHEZMOI_VERSION` set to the oldest
+version that you use. E.g:
+
+```
+CHEZMOI_MODIFY_MANAGER_ASSUME_CHEZMOI_VERSION=2.46.0
+```
+This could be set in your `.bashrc`/`.zshrc`/`.profile` or similar file (the
+details of how to best set environment variables for a particular platform and
+shell is out of scope of this documentation).

--- a/src/add/tests.rs
+++ b/src/add/tests.rs
@@ -22,7 +22,7 @@ use pathdiff::diff_utf8_paths;
 use pretty_assertions::assert_eq;
 use tempfile::{tempdir, TempDir};
 
-use crate::utils::Chezmoi;
+use crate::utils::{Chezmoi, ChezmoiVersion, CHEZMOI_AUTO_SOURCE_VERSION};
 
 use super::internal_filter;
 
@@ -116,6 +116,7 @@ struct DummyChezmoi {
     input_dir: Utf8PathBuf,
     src_dir: Utf8PathBuf,
     dummy_file: Utf8PathBuf,
+    version: ChezmoiVersion,
 }
 
 impl DummyChezmoi {
@@ -132,6 +133,7 @@ impl DummyChezmoi {
             input_dir,
             src_dir,
             dummy_file,
+            version: CHEZMOI_AUTO_SOURCE_VERSION,
         }
     }
 
@@ -163,6 +165,10 @@ impl Chezmoi for DummyChezmoi {
         let expected_path = self.basic_source_path(path);
         std::fs::copy(path, expected_path).unwrap();
         Ok(())
+    }
+
+    fn version(&self) -> anyhow::Result<ChezmoiVersion> {
+        Ok(self.version.clone())
     }
 }
 

--- a/src/add/tests.rs
+++ b/src/add/tests.rs
@@ -147,6 +147,7 @@ impl DummyChezmoi {
 
     fn make_script_path(&self, file_name: &str, style: Style) -> Utf8PathBuf {
         match style {
+            Style::Auto => todo!("Not implemented in test yet"),
             Style::InPath => self.src_dir.join(format!("modify_{file_name}")),
             Style::InPathTmpl | Style::InSrc => {
                 self.src_dir.join(format!("modify_{file_name}.tmpl"))

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -62,11 +62,9 @@ pub enum ChmmArgs {
         files: Vec<Utf8PathBuf>,
     },
     Smart {
-        /// Smartly add a file to be tracked by either chezmoi or chezmoi_mm
+        /// Smartly add a file to be tracked by either chezmoi or chezmoi_modify_manager
         #[bpaf(short('s'), long("smart-add"))]
         _a: (),
-        #[bpaf(external)]
-        style: Style,
         #[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))]
         files: Vec<Utf8PathBuf>,
     },

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -12,7 +12,7 @@ use strum::IntoEnumIterator;
 
 /// Parser for `--style`
 fn style() -> impl Parser<Style> {
-    const DEFAULT: Style = Style::InPath;
+    const DEFAULT: Style = Style::InPathTmpl;
     let iter = Style::iter().map(|x| -> String {
         if x == DEFAULT {
             format!("{x} (default)")
@@ -21,7 +21,7 @@ fn style() -> impl Parser<Style> {
         }
     });
     let help_msg = format!(
-        "How to call the modify manager in the generated file [{}]",
+        "Style of generated modify script [{}]",
         Itertools::intersperse(iter, ", ".to_string()).collect::<String>()
     );
 
@@ -95,9 +95,20 @@ pub enum ChmmArgs {
     },
 }
 
+/// Construct bpaf --help footer
+fn footer() -> bpaf::Doc {
+    // Leading spaces forces newlines to be inserted in bpaf documentation
+    let mut doc = bpaf::Doc::default();
+    doc.text("The --style flag controls how the script that --add generates looks:\n \n");
+    for s in Style::iter() {
+        doc.text(&format!(" * {}: {}", s, s.get_documentation().unwrap()));
+    }
+    doc
+}
+
 /// Apply arg parser to standard arguments
 pub fn parse_args() -> ChmmArgs {
-    chmm_args().run()
+    chmm_args().footer(footer()).run()
 }
 
 #[cfg(test)]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -12,7 +12,7 @@ use strum::IntoEnumIterator;
 
 /// Parser for `--style`
 fn style() -> impl Parser<Style> {
-    const DEFAULT: Style = Style::InPathTmpl;
+    const DEFAULT: Style = Style::Auto;
     let iter = Style::iter().map(|x| -> String {
         if x == DEFAULT {
             format!("{x} (default)")
@@ -21,7 +21,7 @@ fn style() -> impl Parser<Style> {
         }
     });
     let help_msg = format!(
-        "Style of generated modify script [{}]",
+        "Style of newly generated modify script [{}]",
         Itertools::intersperse(iter, ", ".to_string()).collect::<String>()
     );
 
@@ -100,8 +100,12 @@ fn footer() -> bpaf::Doc {
     // Leading spaces forces newlines to be inserted in bpaf documentation
     let mut doc = bpaf::Doc::default();
     doc.text("The --style flag controls how the script that --add generates looks:\n \n");
-    for s in Style::iter() {
-        doc.text(&format!(" * {}: {}", s, s.get_documentation().unwrap()));
+    for style in Style::iter() {
+        let mut text = format!(" * {}: {}", style, style.get_documentation().unwrap());
+        if !text.ends_with('\n') {
+            text.push('\n');
+        }
+        doc.text(&text);
     }
     doc
 }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -21,8 +21,14 @@ pub(super) enum Directive {
     WS,
     /// A source path
     Source(String),
-    /// Automatic source localisation
-    SourceAuto,
+    /// Automatic source localisation (via environment variable)
+    SourceAutoEnv,
+    #[doc(hidden)]
+    /// Automatic source localisation (via relative path)
+    ///
+    /// This is used internally by the integration tests, but doesn't actually
+    /// work with real chezmoi
+    SourceAutoPath,
     /// An ignore directive
     Ignore(Matcher),
     /// A transform directive
@@ -103,7 +109,8 @@ fn source(i: &mut &str) -> PResult<Directive> {
         "source",
         space1,
         alt((
-            "auto".map(|_| Directive::SourceAuto),
+            "auto-path".map(|_| Directive::SourceAutoPath),
+            "auto".map(|_| Directive::SourceAutoEnv),
             quoted_string_nl.map(Directive::Source),
         )),
     )
@@ -399,7 +406,7 @@ mod tests {
         assert_eq!(
             out,
             vec![
-                Directive::SourceAuto,
+                Directive::SourceAutoEnv,
                 Directive::Ignore(Matcher::Section("c".into())),
                 Directive::Ignore(Matcher::Literal("a".into(), "b".into())),
                 Directive::Transform(
@@ -444,7 +451,7 @@ mod tests {
         assert_eq!(
             out,
             vec![
-                Directive::SourceAuto,
+                Directive::SourceAutoEnv,
                 Directive::Source("foo".into()),
                 Directive::Ignore(Matcher::Section("bar".into())),
                 Directive::Ignore(Matcher::Section("quux".into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod utils;
 use indoc::printdoc;
 use ini_merge::merge::merge_ini;
 
-use crate::utils::RealChezmoi;
+use crate::utils::{RealChezmoi, CHEZMOI_AUTO_SOURCE_VERSION};
 
 /// Main function, amenable to integration tests.
 ///
@@ -129,9 +129,14 @@ fn help_syntax() {
     source
     ------
     This directive is required. It specifies where to find the source file
-    (i.e. the file in the dotfile repo). It should have the following format:
+    (i.e. the file in the dotfile repo). It should have the following format
+    to support Chezmoi versions older than {}:
 
     {}
+
+    From Chezmoi {} and forward the following also works instead:
+
+    source auto
 
     ignore
     ------
@@ -233,5 +238,7 @@ fn help_syntax() {
 
     (Matching works identically to ignore, see above for more details.)
     "#,
-    r#"source "{{ .chezmoi.sourceDir }}/{{ .chezmoi.sourceFile | trimSuffix ".tmpl" | replace "modify_" "" }}.src.ini""#};
+    CHEZMOI_AUTO_SOURCE_VERSION,
+    r#"source "{{ .chezmoi.sourceDir }}/{{ .chezmoi.sourceFile | trimSuffix ".tmpl" | replace "modify_" "" }}.src.ini""#,
+    CHEZMOI_AUTO_SOURCE_VERSION};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,13 +79,13 @@ where
                 )?;
             }
         }
-        ChmmArgs::Smart { _a, files, style } => {
+        ChmmArgs::Smart { _a, files } => {
             let mut stdout = stdout();
             for file in files {
                 add::add(
                     &RealChezmoi::default(),
                     add::Mode::Smart,
-                    style,
+                    Style::Auto, // Style unused for the smart case, so doesn't matter
                     &file,
                     &mut stdout,
                 )?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,40 @@
 //! Some shared utility functions
 
-use anyhow::anyhow;
-use camino::{Utf8Path, Utf8PathBuf};
+use std::str::FromStr;
 
+use anyhow::{anyhow, Context};
+use camino::{Utf8Path, Utf8PathBuf};
 use duct::cmd;
+use regex::Regex;
+
+/// Represents the version number of chezmoi
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ChezmoiVersion(pub(crate) i32, pub(crate) i32, pub(crate) i32);
+
+impl FromStr for ChezmoiVersion {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let re = Regex::new(r"v([0-9]+)\.([0-9]+)\.([0-9]+)")?;
+        let caps = re
+            .captures(s)
+            .context("Failed to find chezmoi version string")?;
+        Ok(Self(
+            caps.get(1).unwrap().as_str().parse()?,
+            caps.get(2).unwrap().as_str().parse()?,
+            caps.get(3).unwrap().as_str().parse()?,
+        ))
+    }
+}
+
+impl std::fmt::Display for ChezmoiVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "v{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
+/// Minimum version of chezmoi to support "source auto" directive
+pub(crate) const CHEZMOI_AUTO_SOURCE_VERSION: ChezmoiVersion = ChezmoiVersion(2, 47, 0);
 
 /// Trait for interacting with chezmoi.
 ///
@@ -13,11 +44,14 @@ pub(crate) trait Chezmoi: std::fmt::Debug {
     fn source_path(&self, path: &Utf8Path) -> anyhow::Result<Option<Utf8PathBuf>>;
     fn source_root(&self) -> anyhow::Result<Option<Utf8PathBuf>>;
     fn add(&self, path: &Utf8Path) -> anyhow::Result<()>;
+    fn version(&self) -> anyhow::Result<ChezmoiVersion>;
 }
 
 /// Trait implementation using the real chezmoi
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct RealChezmoi();
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RealChezmoi {
+    version: std::cell::Cell<Option<ChezmoiVersion>>,
+}
 
 impl Chezmoi for RealChezmoi {
     /// Get the source path of a file
@@ -55,5 +89,43 @@ impl Chezmoi for RealChezmoi {
             return Err(anyhow!("chezmoi add failed with error code {}", out.status));
         }
         Ok(())
+    }
+
+    fn version(&self) -> anyhow::Result<ChezmoiVersion> {
+        match self.version.get() {
+            None => {
+                let output = cmd!("chezmoi", "--version")
+                    .stdout_capture()
+                    .stderr_null()
+                    .unchecked()
+                    .run()?;
+                if !output.status.success() {
+                    anyhow::bail!("Failed to run chezmoi --version");
+                }
+                let version: ChezmoiVersion =
+                    String::from_utf8(output.stdout)?.trim_end().parse()?;
+                self.version.set(Some(version));
+                Ok(version)
+            }
+            Some(version) => Ok(version),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::ChezmoiVersion;
+
+    #[test]
+    fn test_chezmoi_version() {
+        let version1 = ChezmoiVersion::from_str("v2.46.0").unwrap();
+        assert_eq!(version1, ChezmoiVersion(2, 46, 0));
+        let version2 =
+            ChezmoiVersion::from_str("chezmoi version v2.47.0, built at 2024-01-26T07:31:10Z")
+                .unwrap();
+        assert_eq!(version2, ChezmoiVersion(2, 47, 0));
+        assert!(version1 < version2);
     }
 }

--- a/tests/data/basics.tmpl
+++ b/tests/data/basics.tmpl
@@ -1,6 +1,6 @@
 #!/this/line/is/ignored/for/integration/tests
 
-source auto
+source auto-path
 
 ignore section "section-sys-ignored"
 ignore section "section-src-ignored"

--- a/tests/data/key_only.tmpl
+++ b/tests/data/key_only.tmpl
@@ -1,5 +1,5 @@
 #!/this/line/is/ignored/for/integration/tests
 
-source auto
+source auto-path
 
 ignore regex ".*" ".*_ignored$"

--- a/tests/data/regex.tmpl
+++ b/tests/data/regex.tmpl
@@ -1,5 +1,5 @@
 #!/this/line/is/ignored/for/integration/tests
 
-source auto
+source auto-path
 
 ignore regex "sec" "aaa|bbb"

--- a/tests/data/set2.tmpl
+++ b/tests/data/set2.tmpl
@@ -1,6 +1,6 @@
 #!/this/line/is/ignored/for/integration/tests
 
-source auto
+source auto-path
 
 set "a" "a" "a" separator="="
 set "b" "b" "b" separator="="

--- a/tests/data/set_remove.tmpl
+++ b/tests/data/set_remove.tmpl
@@ -1,6 +1,6 @@
 #!/this/line/is/ignored/for/integration/tests
 
-source auto
+source auto-path
 
 set "src-sec" "src-key" "quux1"
 set "tgt-sec" "tgt-key" "quux2"

--- a/tests/data/transform.tmpl
+++ b/tests/data/transform.tmpl
@@ -1,6 +1,6 @@
 #!/this/line/is/ignored/for/integration/tests
 
-source auto
+source auto-path
 
 transform "a" "unsorted" unsorted-list separator=","
 transform "a" "mediavolumedown" kde-shortcut

--- a/tests/integration/data_driven.rs
+++ b/tests/integration/data_driven.rs
@@ -24,7 +24,7 @@ fn find_test_cases() -> anyhow::Result<Vec<Utf8PathBuf>> {
         if !path.is_file() {
             continue;
         }
-        if let Some("cfg") = path.extension() {
+        if let Some("tmpl") = path.extension() {
             results.push(path);
         }
     }


### PR DESCRIPTION
This will only work once https://github.com/twpayne/chezmoi/pull/3518 has landed in a release of chezmoi

TODO:

* [ ] Documentation:
  * [x] Document in `--help-syntax`
  * [x] Check README and elsewhere that might need updates
  * [x] Document minimum required chezmoi version for this feature. Relevant locations:
        - CHEZMOI_AUTO_SOURCE_VERSION
        - source_specification.md
  * [ ] Release notes will need an expanded section on this (not just autogenerated from commit messages)
* [x] Functionality
  * [x] Change default add-templates to make use of this
  * [x] Should `--add` have a `--templated` (to add non-templated by default)? What about converting between them? Some thought needed for UX.\
    *Rolled into `--style` for now*
  * [x] Should default value of `--style` differ based on chezmoi version?
  * [x] What should `--add` do when you have an old chezmoi? Do we need to parse the version number? :(\
    *Yes, though see below*
  * [x] What if you use a mix of old and new chezmoi across multiple computers, especially distro installed ones.