### PR TITLE
feat: Switch to dep: syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,20 @@ default = ["updater-tls-rusttls", "keyring"]
 # Support for keyring transform
 keyring = ["ini-merge/keyring"]
 # Built in updater, distro packages probably wants to disable this. Uses rustls for encryption.
-updater-tls-rusttls = ["self_update", "self_update/rustls"]
+updater-tls-rusttls = ["dep:self_update"]
 
 [target.'cfg(windows)'.dependencies]
 self_update = { version = "0.39.0", optional = true, default-features = false, features = [
     "archive-zip",
     "compression-zip-deflate",
+    "rustls",
 ] }
 
 [target.'cfg(unix)'.dependencies]
 self_update = { version = "0.39.0", optional = true, default-features = false, features = [
     "archive-tar",
     "compression-flate2",
+    "rustls",
 ] }
 
 [dependencies]


### PR DESCRIPTION
It would be preferable to use `dep:` but before this didn't pass CI